### PR TITLE
Introduce --verbose flag to make the logs more verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make logging less verbose, and introduce a `--verbose` flag to verbose logging (#62)
+
+## [0.1.0]
+
 - Initial release
 - Instead of only copying the prometheus binary, simply extract everything (#17)
 - Add more flexible endpoints parser (#21)

--- a/src/bin/am/commands.rs
+++ b/src/bin/am/commands.rs
@@ -10,15 +10,26 @@ pub mod system;
 pub struct Application {
     #[command(subcommand)]
     pub command: SubCommands,
+
+    /// Enable verbose logging. By enabling this you are also able to use
+    /// RUST_LOG environment variable to change the log levels of other
+    /// modules.
+    ///
+    /// By default we will only log INFO level messages of all modules. If this
+    /// flag is enabled, then we will log the message from `am` with DEBUG
+    /// level, other modules still use the INFO level.
+    #[clap(long, short)]
+    pub verbose: bool,
 }
 
 #[derive(Subcommand)]
 pub enum SubCommands {
-    /// Start scraping the specified endpoint, while also providing a web
+    /// Start scraping the specified endpoint(s), while also providing a web
     /// interface to inspect the autometrics data.
     Start(start::Arguments),
 
-    /// Manage am related system settings.
+    /// Manage am related system settings. Such as cleaning up downloaded
+    /// Prometheus, Pushgateway installs.
     System(system::Arguments),
 
     #[clap(hide = true)]

--- a/src/bin/am/main.rs
+++ b/src/bin/am/main.rs
@@ -4,9 +4,10 @@ use commands::{handle_command, Application};
 use interactive::IndicatifWriter;
 use tracing::level_filters::LevelFilter;
 use tracing::{debug, error};
+use tracing_subscriber::fmt::format;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 mod commands;
 mod downloader;
@@ -14,11 +15,10 @@ mod interactive;
 
 #[tokio::main]
 async fn main() {
-    let (writer, multi_progress) = IndicatifWriter::new();
-
     let app = Application::parse();
 
-    if let Err(err) = init_logging(writer) {
+    let (writer, multi_progress) = IndicatifWriter::new();
+    if let Err(err) = init_logging(&app, writer) {
         eprintln!("Unable to initialize logging: {:#}", err);
         std::process::exit(1);
     }
@@ -42,15 +42,38 @@ async fn main() {
 /// For example: for local development it is convenient to set the environment
 /// variable to `RUST_LOG=am=trace,info`. This will display all log messages
 /// within the `am` module, but will only show info for other modules.
-fn init_logging(writer: IndicatifWriter) -> Result<()> {
-    // The filter layer controls which log levels to display.
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::default().add_directive(LevelFilter::INFO.into()));
+fn init_logging(app: &Application, writer: IndicatifWriter) -> Result<()> {
+    let (filter_layer, log_layer) = if app.verbose {
+        let filter_layer = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::default().add_directive(LevelFilter::DEBUG.into()));
+        // TODO: ^ only am on DEBUG, rest on INFO
+        let log_layer = tracing_subscriber::fmt::layer().with_writer(writer).boxed();
+        (filter_layer, log_layer)
+    } else {
+        let filter_layer = EnvFilter::default().add_directive(LevelFilter::INFO.into());
+        // Create a custom field formatter, which only outputs the `message`
+        // field, all other fields are ignored.
+        let field_formatter = format::debug_fn(|writer, field, value| {
+            if field.name() == "message" {
+                write!(writer, "{value:?}")
+            } else {
+                Ok(())
+            }
+        });
+        let log_layer = tracing_subscriber::fmt::layer()
+            .fmt_fields(field_formatter)
+            .without_time()
+            .with_level(false)
+            .with_span_events(format::FmtSpan::NONE)
+            .with_target(false)
+            .with_writer(writer)
+            .boxed();
 
-    let log_layer = tracing_subscriber::fmt::layer().with_writer(writer);
+        (filter_layer, log_layer)
+    };
 
     Registry::default()
-        .with(filter)
+        .with(filter_layer)
         .with(log_layer)
         .try_init()
         .context("unable to initialize logger")?;

--- a/src/bin/am/main.rs
+++ b/src/bin/am/main.rs
@@ -47,10 +47,13 @@ fn init_logging(app: &Application, writer: IndicatifWriter) -> Result<()> {
         let filter_layer = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::default().add_directive(LevelFilter::DEBUG.into()));
         // TODO: ^ only am on DEBUG, rest on INFO
+
         let log_layer = tracing_subscriber::fmt::layer().with_writer(writer).boxed();
+
         (filter_layer, log_layer)
     } else {
         let filter_layer = EnvFilter::default().add_directive(LevelFilter::INFO.into());
+
         // Create a custom field formatter, which only outputs the `message`
         // field, all other fields are ignored.
         let field_formatter = format::debug_fn(|writer, field, value| {
@@ -60,6 +63,7 @@ fn init_logging(app: &Application, writer: IndicatifWriter) -> Result<()> {
                 Ok(())
             }
         });
+
         let log_layer = tracing_subscriber::fmt::layer()
             .fmt_fields(field_formatter)
             .without_time()

--- a/src/bin/am/main.rs
+++ b/src/bin/am/main.rs
@@ -45,8 +45,7 @@ async fn main() {
 fn init_logging(app: &Application, writer: IndicatifWriter) -> Result<()> {
     let (filter_layer, log_layer) = if app.verbose {
         let filter_layer = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::default().add_directive(LevelFilter::DEBUG.into()));
-        // TODO: ^ only am on DEBUG, rest on INFO
+            .unwrap_or_else(|_| EnvFilter::try_new("am=debug,info").unwrap());
 
         let log_layer = tracing_subscriber::fmt::layer().with_writer(writer).boxed();
 


### PR DESCRIPTION
The default logs have been made less verbose: they will not show the timestamp, module, log level and fields. The default logging will also ignore RUST_LOG and log everything from INFO and above.

Default logs with `am start`:
![image](https://github.com/autometrics-dev/am/assets/202981/e7d75828-532b-486e-b65f-f7866cf75c0a)


Verbose logs with `am start`:
![image](https://github.com/autometrics-dev/am/assets/202981/09b1dd03-b2aa-4299-955d-79490cdef9ae)

Some further improvements that I think we could do at some point is: when using the default log, prefix `WARN` and `ERROR` with a yellow and red `|` prefix. This is an example from terraform:
![image](https://github.com/autometrics-dev/am/assets/202981/8550b899-b162-4865-a3fe-67ed18410033)
