### PR TITLE
Use host for job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Make logging less verbose, and introduce a `--verbose` flag to verbose logging (#62)
+- Use host and port for job name in Prometheus target list (#66)
 
 ## [0.1.0]
 

--- a/src/bin/am/commands/start.rs
+++ b/src/bin/am/commands/start.rs
@@ -18,7 +18,6 @@ use std::fs::File;
 use std::io::{Seek, SeekFrom};
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::vec;
 use tempfile::NamedTempFile;
@@ -374,11 +373,8 @@ fn to_scrape_config(metric_endpoint: &Url) -> prometheus::ScrapeConfig {
         None => metric_endpoint.host_str().unwrap().to_string(),
     };
 
-    static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    let num = COUNTER.fetch_add(1, Ordering::SeqCst);
-
     prometheus::ScrapeConfig {
-        job_name: format!("app_{num}"),
+        job_name: host.clone(),
         static_configs: vec![prometheus::StaticScrapeConfig {
             targets: vec![host],
         }],


### PR DESCRIPTION
This way the job name is at least predicatable and makes more sense to a user

Related issue: #49