### PR TITLE
Redirect graph to explorer while keeping the querystring intact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if pushgateway is enabled (#67)
 - `honor_labels` will now be set to `true` for the Pushgateway endpoint
   in the generated Prometheus config, if it is enabled (#69)
+- Redirect `/graph` to `/explorer/graph.html` which will load a different JS
+  script from explorer (#84)
 
 ## [0.1.0]
 

--- a/files/explorer/graph.html
+++ b/files/explorer/graph.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="https://explorer.autometrics.dev/favicon.raw.19b993d4.svg"
+    />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Autometrics Explorer - Prometheus</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script
+      src="https://explorer.autometrics.dev/static/js/graph/index.34f33777.js"
+      type="module"
+      id="autometrics-explorer-js"
+    ></script>
+  </body>
+</html>

--- a/src/bin/am/server.rs
+++ b/src/bin/am/server.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use axum::body::Body;
 use axum::response::Redirect;
 use axum::routing::{any, get};
 use axum::{Router, Server};
@@ -20,6 +21,13 @@ pub(crate) async fn start_web_server(
         .route(
             "/explorer",
             get(|| async { Redirect::permanent("/explorer/") }),
+        )
+        .route(
+            "/graph",
+            get(|req: http::Request<Body>| async move {
+                let query = req.uri().query().unwrap_or("");
+                Redirect::temporary(&format!("/explorer/graph.html?{query}"))
+            }),
         )
         .route("/explorer/", get(explorer::handler))
         .route("/explorer/*path", get(explorer::handler))

--- a/src/bin/am/server.rs
+++ b/src/bin/am/server.rs
@@ -25,7 +25,7 @@ pub(crate) async fn start_web_server(
         .route(
             "/graph",
             get(|req: http::Request<Body>| async move {
-                let query = req.uri().query().unwrap_or("");
+                let query = req.uri().query().unwrap_or_default();
                 Redirect::temporary(&format!("/explorer/graph.html?{query}"))
             }),
         )


### PR DESCRIPTION
Resolves: #75

- [x] Changelog updated
