### PR TITLE
Allow the user to specify the scrape interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   script from explorer (#84)
 - Shorthand notion for endpoints defined within the config file (`am.toml`) is now
   allowed (#85)
+- Allow user to specify the Prometheus scrape interval (#87)
 
 ## [0.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,8 @@ dependencies = [
  "futures-util",
  "hex",
  "http",
+ "humantime",
+ "humantime-serde",
  "include_dir",
  "indicatif",
  "once_cell",
@@ -684,6 +686,22 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ flate2 = { version = "1.0.26" }
 futures-util = { version = "0.3.28", features = ["io"] }
 hex = "0.4.3"
 http = { version = "0.2.9" }
+humantime = "2.1.0"
+humantime-serde = "1.1.1"
 include_dir = { version = "0.7.3" }
 indicatif = "0.17.5"
 once_cell = { version = "1.17.1" }

--- a/am.toml
+++ b/am.toml
@@ -1,8 +1,10 @@
 pushgateway-enabled = true
+# prometheus-scrape-interval = "5m"
 
 [[endpoint]]
-# job-name = "main_app"
+job-name = "main_app"
 url = "http://localhost:3030"
+# scrape-interval = "5s"
 
 [[endpoint]]
 job-name = "secondary_app"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::parser::endpoint_parser;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
+use std::time::Duration;
 use url::Url;
 
 /// This struct represents the am.toml configuration. Most properties in here
@@ -15,15 +16,29 @@ pub struct AmConfig {
 
     /// Startup the pushgateway.
     pub pushgateway_enabled: Option<bool>,
+
+    /// The default scrape interval for all Prometheus endpoints.
+    #[serde(default, with = "humantime_serde::option")]
+    pub prometheus_scrape_interval: Option<Duration>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Endpoint {
+    /// The URL of the endpoint that will be scraped by the Prometheus server.
+    /// Can use shorthand notation for the URL, e.g. `:3000`.
     #[serde(deserialize_with = "parse_maybe_shorthand")]
     pub url: Url,
+
+    /// The job name as it appears in Prometheus. This value will be added to
+    /// the scraped metrics as a label.
     pub job_name: Option<String>,
+
     pub honor_labels: Option<bool>,
+
+    /// The scrape interval for this endpoint.
+    #[serde(default, with = "humantime_serde::option")]
+    pub prometheus_scrape_interval: Option<Duration>,
 }
 
 fn parse_maybe_shorthand<'de, D: Deserializer<'de>>(input: D) -> Result<Url, D::Error> {

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::time::Duration;
 
 #[derive(Debug, Serialize)]
 pub struct Config {
@@ -8,7 +9,8 @@ pub struct Config {
 
 #[derive(Debug, Serialize)]
 pub struct GlobalConfig {
-    pub scrape_interval: String,
+    #[serde(with = "humantime_serde")]
+    pub scrape_interval: Duration,
     pub evaluation_interval: String,
 }
 
@@ -19,6 +21,13 @@ pub struct ScrapeConfig {
     pub metrics_path: Option<String>,
     pub scheme: Option<Scheme>,
     pub honor_labels: Option<bool>,
+
+    #[serde(
+        default,
+        with = "humantime_serde::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub scrape_interval: Option<Duration>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
A default for all jobs can be specified through a cli argument or a config in the am.toml. It is also possible for every endpoint to be overridden using the am.toml.

This also introduces a shorter default scrape interval of 5s if nothing was specified.

Group some cli arguments into groups

- [x] Changelog updated

Resolves #86