### PR TITLE
Add display name and use clap-markdown fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,8 +241,7 @@ dependencies = [
 [[package]]
 name = "clap-markdown"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325f50228f76921784b6d9f2d62de6778d834483248eefecd27279174797e579"
+source = "git+https://github.com/keturiosakys/clap-markdown.git#0ec2efed4cf6f1f911000c7cd1b2389e0b628971"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools::profiling"]
 anyhow = { version = "1.0.71" }
 axum = { version = "0.6.18" }
 clap = { version = "4.2.7", features = ["derive", "env"] }
-clap-markdown = "0.1.3"
+clap-markdown = { git = "https://github.com/keturiosakys/clap-markdown.git" }
 dialoguer = "0.10.4"
 directories = { version = "5.0.1" }
 flate2 = { version = "1.0.26" }

--- a/src/bin/am/commands.rs
+++ b/src/bin/am/commands.rs
@@ -10,7 +10,7 @@ pub mod start;
 pub mod system;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, display_name = "am")]
 pub struct Application {
     #[command(subcommand)]
     pub command: SubCommands,


### PR DESCRIPTION
This PR swaps out the original `clap-markdown` crate with a fork that enables display name formatting for better documentation. It also adds an explicit display name for `am`. 

- [ ] Changelog updated
