### PR TITLE
Add 'publish to brew tap' job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,29 @@ jobs:
             /tmp/artifact/${{ matrix.platform.file-name }}
             /tmp/artifact/${{ matrix.platform.file-name }}.sha256
 
+  homebrew-release:
+    runs-on: ubuntu-latest
+    name: Update Homebrew tap formula
+    needs: [attach-artifacts, validate-version]
+
+    steps:
+      - name: prepare folder
+        run: mkdir -p /tmp/artifact
+
+      - name: get the SHA256 artifacts
+        uses: actions/download-artifact
+        with:
+          path: /tmp/artifact
+
+      - name: trigger homebrew workflow
+        working-directory: /tmp/artifact/
+        env:
+          AM_VERSION: ${{ needs.validate-version.outputs.version }}
+        run: |
+          gh workflow run update_formula.yml \
+          -R autometrics-dev/homebrew-tap \
+          -f AM_VERSION=$AM_VERSION \
+          -f SHA256_AARCH64_APPLE_DARWIN=$(cat am-macos-aarch64.sha256 | awk '{print $1}') \
+          -f SHA256_X86_64_APPLE_DARWIN=$(cat am-macos-x86_64.sha256 | awk '{print $1}') \
+          -f SHA256_AARCH64_LINUX_GNU=$(cat am-linux-aarch64.sha256 | awk '{print $1}') \
+          -f SHA256_X86_64_LINUX_GNU=$(cat linux_x86_64.sha256.sha256 | awk '{print $1}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,4 +116,4 @@ jobs:
           -f SHA256_AARCH64_APPLE_DARWIN=$(cat am-macos-aarch64.sha256 | awk '{print $1}') \
           -f SHA256_X86_64_APPLE_DARWIN=$(cat am-macos-x86_64.sha256 | awk '{print $1}') \
           -f SHA256_AARCH64_LINUX_GNU=$(cat am-linux-aarch64.sha256 | awk '{print $1}') \
-          -f SHA256_X86_64_LINUX_GNU=$(cat linux_x86_64.sha256.sha256 | awk '{print $1}')
+          -f SHA256_X86_64_LINUX_GNU=$(cat am-linux-x86_64.sha256 | awk '{print $1}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
         working-directory: /tmp/artifact/
         env:
           AM_VERSION: ${{ needs.validate-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run update_formula.yml \
           -R autometrics-dev/homebrew-tap \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
       - published
   workflow_dispatch:
 
+name: Release new version
 jobs:
   validate-version:
     name: Validate `Cargo.toml` version matches tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,19 @@ jobs:
   validate-version:
     name: validate `Cargo.toml` version matches tag
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.VERSION }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: validate version
+        id: validate
         run: |
           # Extract the version from the Cargo.toml
           VERSION=$(cat "Cargo.toml" | grep '^version' | awk '{ split($0,version,"=") ; gsub(/[\ \"]/, "", version[2]) ; print version[2] }')
+          echo $VERSION >> "$GITHUB_OUTPUT"
           if [ "v${VERSION}" != "${{ github.event.release.tag_name }}" ]; then
             echo "::error file=Cargo.toml::Version set in Cargo.toml (v${VERSION}) does not match release version (${{ github.event.release.tag_name }})"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,27 +53,35 @@ jobs:
             target: aarch64-apple-darwin
             bin: am
             file-name: am-macos-aarch64
+
     runs-on: ${{ matrix.platform.os }}
     steps:
+
       - name: checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: build
         uses: houseabsolute/actions-rust-cross@v0
         with:
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true
+
       - name: prepare binary
         run: |
           mkdir -p /tmp/artifact/
           cp "target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}" "/tmp/artifact/${{ matrix.platform.file-name }}"
+
       - name: calculate sha256sum
         run: sha256sum /tmp/artifact/${{ matrix.platform.file-name }} >> /tmp/artifact/${{ matrix.platform.file-name }}.sha256
+
+
       - name: attach artifact to release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             /tmp/artifact/${{ matrix.platform.file-name }}
             /tmp/artifact/${{ matrix.platform.file-name }}.sha256
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         run: mkdir -p /tmp/artifact
 
       - name: get the SHA256 artifacts
-        uses: actions/download-artifact
+        uses: actions/download-artifact@v3
         with:
           path: /tmp/artifact
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   validate-version:
@@ -16,6 +17,7 @@ jobs:
 
       - name: Validate version
         id: validate
+        if: github.event_name == 'release'
         run: |
           # Extract the version from the Cargo.toml
           VERSION=$(cat "Cargo.toml" | grep '^version' | awk '{ split($0,version,"=") ; gsub(/[\ \"]/, "", version[2]) ; print version[2] }')
@@ -87,6 +89,7 @@ jobs:
   finalize-release:
     name: Upload artifacts, trigger homebrew workflow
     needs: [build-artifacts, validate-version]
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
       - name: calculate sha256sum
         run: sha256sum /tmp/artifact/${{ matrix.platform.file-name }} >> /tmp/artifact/${{ matrix.platform.file-name }}.sha256
 
+      - name: upload SHA256 for next step
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.platform.file-name }}.sha256
+          path: /tmp/artifact/${{ matrix.platform.file-name }}.sha256
 
       - name: attach artifact to release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,115 +5,119 @@ on:
 
 jobs:
   validate-version:
-    name: validate `Cargo.toml` version matches tag
+    name: Validate `Cargo.toml` version matches tag
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.validate.outputs.VERSION }}
+      version: ${{ steps.validate.outputs.version }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: validate version
+
+      - name: Validate version
         id: validate
         run: |
           # Extract the version from the Cargo.toml
           VERSION=$(cat "Cargo.toml" | grep '^version' | awk '{ split($0,version,"=") ; gsub(/[\ \"]/, "", version[2]) ; print version[2] }')
-          echo $VERSION >> "$GITHUB_OUTPUT"
+          echo version=$VERSION >> "$GITHUB_OUTPUT"
           if [ "v${VERSION}" != "${{ github.event.release.tag_name }}" ]; then
             echo "::error file=Cargo.toml::Version set in Cargo.toml (v${VERSION}) does not match release version (${{ github.event.release.tag_name }})"
             exit 1
           fi
 
-  attach-artifacts:
-    name: (${{ matrix.platform.name }}) build and attach artifacts to release
-    permissions:
-      contents: write
+  build-artifacts:
+    name: Build (${{ matrix.platform.name }})
     needs: validate-version
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
         platform:
-          - name: linux_x86_64
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            bin: am
-            file-name: am-linux-x86_64
           - name: linux_aarch64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             bin: am
             file-name: am-linux-aarch64
-          - name: macos_x86_64
-            os: macOS-latest
-            target: x86_64-apple-darwin
+          - name: linux_x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
             bin: am
-            file-name: am-macos-x86_64
+            file-name: am-linux-x86_64
           - name: macos_aarch64
             os: macOS-latest
             target: aarch64-apple-darwin
             bin: am
             file-name: am-macos-aarch64
-
-    runs-on: ${{ matrix.platform.os }}
+          - name: macos_x86_64
+            os: macOS-latest
+            target: x86_64-apple-darwin
+            bin: am
+            file-name: am-macos-x86_64
     steps:
-
-      - name: checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: build
+      - name: Build
         uses: houseabsolute/actions-rust-cross@v0
         with:
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true
 
-      - name: prepare binary
+      - name: Prepare binary
         run: |
           mkdir -p /tmp/artifact/
           cp "target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}" "/tmp/artifact/${{ matrix.platform.file-name }}"
 
-      - name: calculate sha256sum
+      - name: Calculate sha256sum
         run: sha256sum /tmp/artifact/${{ matrix.platform.file-name }} >> /tmp/artifact/${{ matrix.platform.file-name }}.sha256
 
-      - name: upload SHA256 for next step
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.platform.file-name }}
+          path: /tmp/artifact/${{ matrix.platform.file-name }}
+
+      - name: Upload SHA256
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.platform.file-name }}.sha256
           path: /tmp/artifact/${{ matrix.platform.file-name }}.sha256
 
-      - name: attach artifact to release
+  finalize-release:
+    name: Upload artifacts, trigger homebrew workflow
+    needs: [build-artifacts, validate-version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download am artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifacts
+
+      - name: Attach artifacts to release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            /tmp/artifact/${{ matrix.platform.file-name }}
-            /tmp/artifact/${{ matrix.platform.file-name }}.sha256
+            am-linux-aarch64
+            am-linux-aarch64.sha256
+            am-linux-x86_64
+            am-linux-x86_64.sha256
+            am-macos-aarch64
+            am-macos-aarch64.sha256
+            am-macos-x86_64
+            am-macos-x86_64.sha256
 
-  homebrew-release:
-    runs-on: ubuntu-latest
-    name: Update Homebrew tap formula
-    needs: [attach-artifacts, validate-version]
-
-    steps:
-      - name: prepare folder
-        run: mkdir -p /tmp/artifact
-
-      - name: get the SHA256 artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: /tmp/artifact
-
-      - name: trigger homebrew workflow
-        working-directory: /tmp/artifact/
+      - name: Trigger homebrew workflow
         env:
           AM_VERSION: ${{ needs.validate-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run update_formula.yml \
-          -R autometrics-dev/homebrew-tap \
-          -f AM_VERSION=$AM_VERSION \
-          -f SHA256_AARCH64_APPLE_DARWIN=$(cat am-macos-aarch64.sha256 | awk '{print $1}') \
-          -f SHA256_X86_64_APPLE_DARWIN=$(cat am-macos-x86_64.sha256 | awk '{print $1}') \
-          -f SHA256_AARCH64_LINUX_GNU=$(cat am-linux-aarch64.sha256 | awk '{print $1}') \
-          -f SHA256_X86_64_LINUX_GNU=$(cat am-linux-x86_64.sha256 | awk '{print $1}')
+            -R autometrics-dev/homebrew-tap \
+            -f AM_VERSION=$AM_VERSION \
+            -f SHA256_AARCH64_APPLE_DARWIN=$(cat am-macos-aarch64.sha256 | awk '{print $1}') \
+            -f SHA256_AARCH64_LINUX_GNU=$(cat am-linux-aarch64.sha256 | awk '{print $1}') \
+            -f SHA256_X86_64_APPLE_DARWIN=$(cat am-macos-x86_64.sha256 | awk '{print $1}') \
+            -f SHA256_X86_64_LINUX_GNU=$(cat am-linux-x86_64.sha256 | awk '{print $1}')


### PR DESCRIPTION
This PR introduces a series of enhancements to the release workflow.

1. **Formatting**: adds some spacing so actions are a bit more readable.

2. **Output a version:** Outputs the version from `validate-version` job so that future jobs within the workflow can access it.

3. **Artifact Upload:** Upload the SHA256 artifacts so that future jobs can access it.

4. **Homebrew Release:** The most significant addition is a new job for Homebrew release. This job awaits the completion of the other two jobs, retrieves the version value, prepares a temporary folder, and downloads the necessary artifacts. Once these steps are complete, it triggers the workflow request with the other data. This job automates the process of releasing the project on Homebrew, making it more efficient and less error-prone.

- [x] ~~Changelog updated~~
- [ ] Github Token added: https://github.com/autometrics-dev/am/pull/108/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R119
