### PR TITLE
Fix multiarch docker image for arm64 users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,10 @@ jobs:
 
       - name: Prepare files
         run: |
-          mkdir -p build/linux/{amd64,arm64v8}/
+          mkdir -p build/linux/{amd64,arm64}/
           mv artifacts/am-linux-x86_64/am build/linux/amd64/am
-          mv artifacts/am-linux-aarch64/am build/linux/arm64v8/am
-          chmod u+x build/linux/{amd64,arm64v8}/am
+          mv artifacts/am-linux-aarch64/am build/linux/arm64/am
+          chmod u+x build/linux/{amd64,arm64}/am
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -112,7 +112,7 @@ jobs:
         with:
           file: Dockerfile.release
           context: build
-          platforms: linux/amd64,linux/arm64v8
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: |
             fiberplane/am:v${{ needs.validate-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           file: Dockerfile.release
           context: build
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             fiberplane/am:v${{ needs.validate-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
           push: true
           tags: |
             fiberplane/am:v${{ needs.validate-version.outputs.version }}
+            fiberplane/am:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dump logs if prometheus or pushgateway return a non 0 exit code (#122)
 - Change the default explorer endpoint of when using `am explorer` (#120)
 - Update all depdencies (#124)
+- Fix multiarch docker image for arm64 users (#125)
 
 ## [0.3.0]
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,7 +2,7 @@
 # Use the context that contains the am binaries in the `$OS/$ARCH/am` structure.
 # NOTE: Windows is currently not supported
 
-FROM ${TARGETARCH}/debian:bookworm-slim
+FROM debian:bookworm-slim
 
 # These variables _should_ be set by docker buildx
 ARG TARGETARCH


### PR DESCRIPTION
The Docker image shouldn't use a specific architecture as the base image, and
the platform should require a `/` between the architecture and variant.

NOTE: This does mean that this will probably not work correctly when we have multiple
ARM variants. Possibly we can use the `TARGETVARIANT` for the `COPY` statement.

# Checklist

- [x] Changelog updated
