### PR TITLE
Markdown reference generator - disable toc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the default explorer endpoint of when using `am explorer` (#120)
 - Update all depdencies (#124)
 - Fix multiarch docker image for arm64 users (#125)
+- Update markdown reference generator command to disable TOC (#127)
 
 ## [0.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "clap-markdown"
 version = "0.1.3"
-source = "git+https://github.com/keturiosakys/clap-markdown.git#0ec2efed4cf6f1f911000c7cd1b2389e0b628971"
+source = "git+https://github.com/keturiosakys/clap-markdown.git#0361f85add9cbe87462773406c08b31df6a94f3f"
 dependencies = [
  "clap",
 ]

--- a/src/bin/am/commands.rs
+++ b/src/bin/am/commands.rs
@@ -12,7 +12,7 @@ pub mod system;
 pub mod update;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None, display_name = "am")]
+#[command(author, version, about, long_about = None, bin_name = "am")]
 pub struct Application {
     #[command(subcommand)]
     pub command: SubCommands,
@@ -77,7 +77,8 @@ pub async fn handle_command(app: Application, config: AmConfig, mp: MultiProgres
         }
         SubCommands::Update(args) => update::handle_command(args, mp).await,
         SubCommands::MarkdownHelp => {
-            clap_markdown::print_help_markdown::<Application>();
+            let disable_toc = true;
+            clap_markdown::print_help_markdown::<Application>(Some(disable_toc));
             Ok(())
         }
     }

--- a/src/bin/am/commands/update.rs
+++ b/src/bin/am/commands/update.rs
@@ -145,8 +145,12 @@ pub(crate) async fn update_check() {
         return;
     }
 
-    let Ok(release) = latest_release().await else { return };
-    let Ok(needs_update) = update_needed(&release) else { return };
+    let Ok(release) = latest_release().await else {
+        return;
+    };
+    let Ok(needs_update) = update_needed(&release) else {
+        return;
+    };
 
     if let Err(err) = OpenOptions::new()
         .create(true)


### PR DESCRIPTION
This small PR updates the `clap_markdown` dependency, replaces display_name with bin_name, and adds disable_toc for markdown reference generator

# Checklist

- [x] Changelog updated
