### PR TITLE
fix `version` grep for `Cargo.toml` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           # Extract the version from the Cargo.toml
-          VERSION=$(cat "Cargo.toml" | grep '^version' | awk '{ split($0,version,"=") ; gsub(/[\ \"]/, "", version[2]) ; print version[2] }')
+          VERSION=$(cat "Cargo.toml" | grep '^version =' | awk '{ split($0,version,"=") ; gsub(/[\ \"]/, "", version[2]) ; print version[2] }')
           echo version=$VERSION >> "$GITHUB_OUTPUT"
           echo "Cargo.toml version: \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
           if [ "v${VERSION}" != "${{ github.event.release.tag_name }}" ]; then


### PR DESCRIPTION
doing `grep '^version'` yields two results instead of one since we introduced the `am` workspace in pr #131, as  `Cargo.toml` has now two `version` fields, one for `workspace.package` and one for `package`. as the later one just uses the workspace one anyways, we only check for the workspace one now.

# Checklist

- [x] ~~Changelog updated~~
