### PR TITLE
[am list] Add subcommand to instrument source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Rust dependencies (#150)
 - Update default versions of Prometheus and Pushgateway (#150)
 - Add ability to scrape the metrics of `am`s own web server with `am start --scrape-self` (#153)
+- `am list` now properly detects functions instrumented in Typescript using the `Autometrics` decorator (#152)
+- `am instrument` is a new subcommand that can automatically add annotations to instrument a project (#152)
+   + it works in Go, Python, Typescript, and Rust projects 
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "hex",
  "http",
  "humantime",
+ "ignore",
  "include_dir",
  "indicatif",
  "itertools",
@@ -96,6 +97,8 @@ name = "am_list"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "crop",
+ "ignore",
  "itertools",
  "log",
  "pretty_assertions",
@@ -353,6 +356,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crop"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e7b88784eea5a7895d70cde2535b36030ae387adde16a1d5c962c5ec5f273f"
+dependencies = [
+ "str_indices",
 ]
 
 [[package]]
@@ -853,6 +875,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1084,23 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2374,6 +2426,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_indices"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8eeaedde8e50d8a331578c9fa9a288df146ce5e16173ad26ce82f6e263e2be4"
 
 [[package]]
 name = "strsim"

--- a/am/Cargo.toml
+++ b/am/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = { version = "0.3.28", features = ["io"] }
 hex = "0.4.3"
 http = "0.2.9"
 humantime = { workspace = true }
+ignore = "0.4.20"
 include_dir = "0.7.3"
 indicatif = "0.17.5"
 itertools = "0.11.0"

--- a/am/src/commands.rs
+++ b/am/src/commands.rs
@@ -7,6 +7,7 @@ use tracing::info;
 
 mod explore;
 mod init;
+mod instrument;
 mod list;
 mod proxy;
 pub mod start;
@@ -64,6 +65,14 @@ pub enum SubCommands {
     /// List the functions in a project
     List(list::Arguments),
 
+    /// Instrument a project entirely.
+    ///
+    /// IMPORTANT: This will add code in your files! If you want to easily
+    /// undo the effects of this command, stage your work in progress (using `git add` or similar)
+    /// So that a command like `git restore .` can undo all unstaged changes, leaving your work
+    /// in progress alone.
+    Instrument(instrument::Arguments),
+
     #[clap(hide = true)]
     MarkdownHelp,
 }
@@ -86,6 +95,7 @@ pub async fn handle_command(app: Application, config: AmConfig, mp: MultiProgres
         }
         SubCommands::Update(args) => update::handle_command(args, mp).await,
         SubCommands::List(args) => list::handle_command(args),
+        SubCommands::Instrument(args) => instrument::handle_command(args),
         SubCommands::MarkdownHelp => {
             let disable_toc = true;
             clap_markdown::print_help_markdown::<Application>(Some(disable_toc));

--- a/am/src/commands/instrument.rs
+++ b/am/src/commands/instrument.rs
@@ -1,0 +1,115 @@
+use am_list::Language;
+use anyhow::Context;
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+use tracing::info;
+
+#[derive(Args)]
+pub struct Arguments {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Instrument functions in a single project, giving the language implementation
+    ///
+    /// IMPORTANT: This will add code in your files! If you want to easily
+    /// undo the effects of this command, stage your work in progress (using `git add` or similar)
+    /// So that a command like `git restore .` can undo all unstaged changes, leaving your work
+    /// in progress alone.
+    Single(SingleProject),
+    /// Instrument functions in all projects under the given directory, detecting languages on a best-effort basis.
+    ///
+    /// IMPORTANT: This will add code in your files! If you want to easily
+    /// undo the effects of this command, stage your work in progress (using `git add` or similar)
+    /// So that a command like `git restore .` can undo all unstaged changes, leaving your work
+    /// in progress alone.
+    All(AllProjects),
+}
+
+#[derive(Args)]
+struct SingleProject {
+    /// Language to detect autometrics functions for. Valid values are:
+    /// - 'rust' or 'rs' for Rust,
+    /// - 'go' for Golang,
+    /// - 'typescript', 'ts', 'javascript', or 'js' for Typescript/Javascript,
+    /// - 'python' or 'py' for Python.
+    #[arg(short, long, value_name = "LANGUAGE", verbatim_doc_comment)]
+    language: Language,
+    /// Root of the project to start the search on:
+    /// - For Rust projects it must be where the Cargo.toml lie,
+    /// - For Go projects it must be the root of the repository,
+    /// - For Python projects it must be the root of the library,
+    /// - For Typescript projects it must be where the package.json lie.
+    #[arg(value_name = "ROOT", verbatim_doc_comment)]
+    root: PathBuf,
+    /// A list of patterns to exclude from instrumentation. The patterns follow .gitignore rules, so
+    /// `--exclude "/vendor/"` will exclude all the vendor subdirectory only at the root, and adding
+    /// a pattern that starts with `!` will unignore a file or directory
+    #[arg(short, long, value_name = "PATTERNS")]
+    exclude: Vec<String>,
+}
+
+#[derive(Args)]
+struct AllProjects {
+    /// Main directory to start the subprojects search on. am currently detects
+    /// Rust (Cargo.toml), Typescript (package.json), and Golang (go.mod)
+    /// projects.
+    #[arg(value_name = "ROOT")]
+    root: PathBuf,
+    /// A list of patterns to exclude from instrumentation. The patterns follow .gitignore rules, so
+    /// `--exclude "/vendor/"` will exclude all the vendor subdirectory only at the root, and adding
+    /// a pattern that starts with `!` will unignore a file or directory
+    #[arg(short, long, value_name = "PATTERNS")]
+    exclude: Vec<String>,
+}
+
+pub fn handle_command(args: Arguments) -> anyhow::Result<()> {
+    match args.command {
+        Command::Single(args) => handle_single_project(args),
+        Command::All(args) => handle_all_projects(args),
+    }
+}
+
+fn handle_all_projects(args: AllProjects) -> Result<(), anyhow::Error> {
+    let root = args
+        .root
+        .canonicalize()
+        .context("The path must be resolvable to an absolute path")?;
+    info!("Instrumenting functions in {}:", root.display());
+
+    let mut exclude_patterns_builder = ignore::gitignore::GitignoreBuilder::new(&root);
+    for pattern in args.exclude {
+        exclude_patterns_builder.add_line(None, &pattern)?;
+    }
+    let exclude_patterns = exclude_patterns_builder.build()?;
+
+    am_list::instrument_all_project_files(&root, &exclude_patterns)?;
+
+    println!("If your project has Golang files, you need to run `go generate` now.");
+
+    Ok(())
+}
+
+fn handle_single_project(args: SingleProject) -> Result<(), anyhow::Error> {
+    let root = args
+        .root
+        .canonicalize()
+        .context("The path must be resolvable to an absolute path")?;
+    info!("Instrumenting functions in {}:", root.display());
+
+    let mut exclude_patterns_builder = ignore::gitignore::GitignoreBuilder::new(&root);
+    for pattern in args.exclude {
+        exclude_patterns_builder.add_line(None, &pattern)?;
+    }
+    let exclude_patterns = exclude_patterns_builder.build()?;
+
+    am_list::instrument_single_project_files(&root, args.language, &exclude_patterns)?;
+
+    if args.language == Language::Go {
+        println!("You need to run `go generate` now.");
+    }
+
+    Ok(())
+}

--- a/am/src/commands/list.rs
+++ b/am/src/commands/list.rs
@@ -3,10 +3,6 @@ use clap::{Args, Subcommand};
 use std::path::PathBuf;
 use tracing::info;
 
-// TODO(gagbo): add an additional subcommand that makes use of am_list::find_roots to
-// list all the functions under a given folder, by detecting the languages and all the
-// subprojects included.
-
 #[derive(Args)]
 pub struct Arguments {
     #[command(subcommand)]

--- a/am_list/Cargo.toml
+++ b/am_list/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.71"
+crop = "0.4.0"
+ignore = "0.4.20"
 itertools = "0.11.0"
 log = "0.4.18"
 rayon = "1.7.0"

--- a/am_list/runtime/queries/typescript/all_functions.scm
+++ b/am_list/runtime/queries/typescript/all_functions.scm
@@ -7,7 +7,12 @@
 (lexical_declaration
  (variable_declarator
   name: (identifier) @func.name
-  value: (arrow_function)))
+  value: (arrow_function) @func.value))
+
+(lexical_declaration
+ (variable_declarator
+  name: (identifier) @func.name
+  value: (function) @func.value))
 
 (class_declaration
  name: (type_identifier) @type.name

--- a/am_list/runtime/queries/typescript/autometrics.scm
+++ b/am_list/runtime/queries/typescript/autometrics.scm
@@ -57,3 +57,14 @@
           (method_definition
            name: (property_identifier) @method.name)]))
  (#eq? @decorator.name "Autometrics"))
+
+((class_declaration
+  decorator: (decorator (call_expression
+                           function: (identifier) @decorator.name))
+  name: (type_identifier) @type.name
+  body: (class_body
+         [(method_signature
+           name: (property_identifier) @method.name)
+          (method_definition
+           name: (property_identifier) @method.name)]))
+ (#eq? @decorator.name "Autometrics"))

--- a/am_list/src/go.rs
+++ b/am_list/src/go.rs
@@ -1,6 +1,7 @@
 mod queries;
 
-use crate::{FunctionInfo, ListAmFunctions, Result};
+use crate::{FunctionInfo, InstrumentFile, ListAmFunctions, Result};
+use log::debug;
 use queries::{AllFunctionsQuery, AmQuery};
 use rayon::prelude::*;
 use std::{
@@ -34,17 +35,30 @@ impl Impl {
                 .map(|s| s.ends_with(".go"))
                 .unwrap_or(false)
     }
-}
 
-impl ListAmFunctions for Impl {
-    fn list_autometrics_functions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
+    fn list_files(
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Vec<String> {
         const PREALLOCATED_ELEMS: usize = 100;
-        let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
-
         let walker = WalkDir::new(project_root).into_iter();
-        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
-        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
+        let mut project_files = Vec::with_capacity(PREALLOCATED_ELEMS);
+        project_files.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
             let entry = entry.ok()?;
+
+            if let Some(pattern) = exclude_patterns {
+                let ignore_match =
+                    pattern.matched_path_or_any_parents(entry.path(), entry.file_type().is_dir());
+                if matches!(ignore_match, ignore::Match::Ignore(_)) {
+                    debug!(
+                        "The exclusion pattern got a match on {}: {:?}",
+                        entry.path().display(),
+                        ignore_match
+                    );
+                    return None;
+                }
+            }
+
             Some(
                 entry
                     .path()
@@ -54,7 +68,19 @@ impl ListAmFunctions for Impl {
             )
         }));
 
-        list.par_extend(source_mod_pairs.par_iter().filter_map(move |path| {
+        project_files
+    }
+}
+
+impl ListAmFunctions for Impl {
+    fn list_autometrics_functions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
+        const PREALLOCATED_ELEMS: usize = 100;
+        let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
+
+        let project_files = Self::list_files(project_root, None);
+        let query = AmQuery::try_new()?;
+
+        list.par_extend(project_files.par_iter().filter_map(move |path| {
             let source = read_to_string(path).ok()?;
             let file_name = PathBuf::from(path)
                 .strip_prefix(project_root)
@@ -62,7 +88,6 @@ impl ListAmFunctions for Impl {
                 .to_str()
                 .expect("file_name is a valid path as it is part of `path`")
                 .to_string();
-            let query = AmQuery::try_new().ok()?;
             let names = query
                 .list_function_names(&file_name, &source)
                 .unwrap_or_default();
@@ -78,20 +103,10 @@ impl ListAmFunctions for Impl {
         const PREALLOCATED_ELEMS: usize = 100;
         let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
 
-        let walker = WalkDir::new(project_root).into_iter();
-        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
-        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
-            let entry = entry.ok()?;
-            Some(
-                entry
-                    .path()
-                    .to_str()
-                    .map(ToString::to_string)
-                    .unwrap_or_default(),
-            )
-        }));
+        let project_files = Self::list_files(project_root, None);
+        let query = AllFunctionsQuery::try_new()?;
 
-        list.par_extend(source_mod_pairs.par_iter().filter_map(move |path| {
+        list.par_extend(project_files.par_iter().filter_map(move |path| {
             let source = read_to_string(path).ok()?;
             let file_name = PathBuf::from(path)
                 .strip_prefix(project_root)
@@ -99,7 +114,6 @@ impl ListAmFunctions for Impl {
                 .to_str()
                 .expect("file_name is a valid path as it is part of `path`")
                 .to_string();
-            let query = AllFunctionsQuery::try_new().ok()?;
             let names = query
                 .list_function_names(&file_name, &source)
                 .unwrap_or_default();
@@ -109,6 +123,82 @@ impl ListAmFunctions for Impl {
         let mut result = Vec::with_capacity(PREALLOCATED_ELEMS);
         result.extend(list.into_iter().flatten());
         Ok(result)
+    }
+
+    fn list_autometrics_functions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        let query = AmQuery::try_new()?;
+        query.list_function_names("<single file>", source_code)
+    }
+
+    fn list_all_function_definitions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        let query = AllFunctionsQuery::try_new()?;
+        query.list_function_names("<single file>", source_code)
+    }
+}
+
+impl InstrumentFile for Impl {
+    fn instrument_source_code(&mut self, source: &str) -> Result<String> {
+        let mut locations = self.list_all_functions_in_single_file(source)?;
+        locations.sort_by_key(|info| {
+            info.definition
+                .as_ref()
+                .map(|def| def.range.start.line)
+                .unwrap_or_default()
+        });
+
+        let has_am_directive = source
+            .lines()
+            .any(|line| line.starts_with("//go:generate autometrics"));
+
+        let mut new_code = crop::Rope::from(source);
+        // Keeping track of inserted lines to update the byte offset to insert code to,
+        // only works if the locations list is sorted from top to bottom
+        let mut inserted_lines = 0;
+
+        if !has_am_directive {
+            new_code.insert(0, "//go:generate autometrics --otel\n");
+            inserted_lines += 1;
+        }
+
+        for function_info in locations {
+            if function_info.definition.is_none() || function_info.instrumentation.is_some() {
+                continue;
+            }
+
+            let def_line = function_info.definition.as_ref().unwrap().range.start.line;
+            let byte_offset = new_code.byte_of_line(inserted_lines + def_line);
+            new_code.insert(byte_offset, "//autometrics:inst\n");
+            inserted_lines += 1;
+        }
+
+        Ok(new_code.to_string())
+    }
+
+    fn instrument_project(
+        &mut self,
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Result<()> {
+        let sources_modules = Self::list_files(project_root, exclude_patterns);
+        debug!("Found sources {sources_modules:?}");
+
+        for path in sources_modules {
+            if std::fs::metadata(&path)?.is_dir() {
+                continue;
+            }
+            debug!("Instrumenting {path}");
+            let old_source = read_to_string(&path)?;
+            let new_source = self.instrument_source_code(&old_source)?;
+            std::fs::write(path, new_source)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/am_list/src/rust.rs
+++ b/am_list/src/rust.rs
@@ -1,7 +1,8 @@
 mod queries;
 
 use self::queries::{AllFunctionsQuery, AmQuery};
-use crate::{FunctionInfo, ListAmFunctions, Result};
+use crate::{FunctionInfo, InstrumentFile, ListAmFunctions, Result};
+use log::debug;
 use rayon::prelude::*;
 use std::{
     collections::{HashSet, VecDeque},
@@ -89,18 +90,31 @@ impl Impl {
 
         itertools::intersperse(mod_name_elements, "::".to_string()).collect()
     }
-}
 
-impl ListAmFunctions for Impl {
-    fn list_autometrics_functions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
+    fn list_files_and_modules(
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Vec<(String, String)> {
         const PREALLOCATED_ELEMS: usize = 100;
-        let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
 
         let walker = WalkDir::new(project_root).into_iter();
         let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
-        let query = AmQuery::try_new()?;
         source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
             let entry = entry.ok()?;
+
+            if let Some(pattern) = exclude_patterns {
+                let ignore_match =
+                    pattern.matched_path_or_any_parents(entry.path(), entry.file_type().is_dir());
+                if matches!(ignore_match, ignore::Match::Ignore(_)) {
+                    debug!(
+                        "The exclusion pattern got a match on {}: {:?}",
+                        entry.path().display(),
+                        ignore_match
+                    );
+                    return None;
+                }
+            }
+
             let module = Self::fully_qualified_module_name(&entry);
             Some((
                 entry
@@ -111,6 +125,17 @@ impl ListAmFunctions for Impl {
                 module,
             ))
         }));
+
+        source_mod_pairs
+    }
+}
+
+impl ListAmFunctions for Impl {
+    fn list_autometrics_functions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
+        const PREALLOCATED_ELEMS: usize = 100;
+        let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
+        let query = AmQuery::try_new()?;
+        let source_mod_pairs = Self::list_files_and_modules(project_root, None);
 
         list.par_extend(
             source_mod_pairs
@@ -138,22 +163,8 @@ impl ListAmFunctions for Impl {
     fn list_all_function_definitions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
         const PREALLOCATED_ELEMS: usize = 400;
         let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
-
-        let walker = WalkDir::new(project_root).into_iter();
-        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
+        let source_mod_pairs = Self::list_files_and_modules(project_root, None);
         let query = AllFunctionsQuery::try_new()?;
-        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
-            let entry = entry.ok()?;
-            let module = Self::fully_qualified_module_name(&entry);
-            Some((
-                entry
-                    .path()
-                    .to_str()
-                    .map(ToString::to_string)
-                    .unwrap_or_default(),
-                module,
-            ))
-        }));
 
         list.par_extend(
             source_mod_pairs
@@ -176,6 +187,72 @@ impl ListAmFunctions for Impl {
         let mut result = Vec::with_capacity(PREALLOCATED_ELEMS);
         result.extend(list.into_iter().flatten());
         Ok(result)
+    }
+
+    fn list_autometrics_functions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        let query = AmQuery::try_new()?;
+        query.list_function_names("<single file>", String::new(), source_code)
+    }
+
+    fn list_all_function_definitions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        let query = AllFunctionsQuery::try_new()?;
+        query.list_function_names("<single file>", String::new(), source_code)
+    }
+}
+
+impl InstrumentFile for Impl {
+    fn instrument_source_code(&mut self, source: &str) -> Result<String> {
+        let mut locations = self.list_all_functions_in_single_file(source)?;
+        locations.sort_by_key(|info| {
+            info.definition
+                .as_ref()
+                .map(|def| def.range.start.line)
+                .unwrap_or_default()
+        });
+
+        let mut new_code = crop::Rope::from(source);
+        // Keeping track of inserted lines to update the byte offset to insert code to,
+        // only works if the locations list is sorted from top to bottom
+        let mut inserted_lines = 0;
+
+        for function_info in locations {
+            if function_info.definition.is_none() || function_info.instrumentation.is_some() {
+                continue;
+            }
+
+            let def_line = function_info.definition.as_ref().unwrap().range.start.line;
+            let byte_offset = new_code.byte_of_line(inserted_lines + def_line);
+            new_code.insert(byte_offset, "#[autometrics::autometrics]\n");
+            inserted_lines += 1;
+        }
+
+        Ok(new_code.to_string())
+    }
+
+    fn instrument_project(
+        &mut self,
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Result<()> {
+        let sources_modules = Self::list_files_and_modules(project_root, exclude_patterns);
+
+        for (path, _module) in sources_modules {
+            if std::fs::metadata(&path)?.is_dir() {
+                continue;
+            }
+            debug!("Instrumenting {path}");
+            let old_source = read_to_string(&path)?;
+            let new_source = self.instrument_source_code(&old_source)?;
+            std::fs::write(path, new_source)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/am_list/src/typescript.rs
+++ b/am_list/src/typescript.rs
@@ -1,7 +1,8 @@
 mod imports;
 mod queries;
 
-use crate::{FunctionInfo, ListAmFunctions, Result};
+use crate::{FunctionInfo, InstrumentFile, ListAmFunctions, Result};
+use log::{debug, trace};
 use rayon::prelude::*;
 use std::{
     collections::{HashSet, VecDeque},
@@ -10,7 +11,7 @@ use std::{
 };
 use walkdir::{DirEntry, WalkDir};
 
-use self::queries::{AllFunctionsQuery, AmQuery};
+use self::queries::{AllFunctionsQuery, AmQuery, TypescriptFunctionInfo};
 
 /// Implementation of the Typescript support for listing autometricized functions.
 #[derive(Clone, Copy, Debug, Default)]
@@ -68,26 +69,57 @@ impl Impl {
         }
         itertools::intersperse(mod_name_elements, "/".to_string()).collect()
     }
+
+    fn ts_function_definitions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<TypescriptFunctionInfo>> {
+        let query = AllFunctionsQuery::try_new()?;
+        query.list_function_names("<single file>", "", source_code)
+    }
+
+    fn list_files_and_modules(
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Vec<(PathBuf, String)> {
+        const PREALLOCATED_ELEMS: usize = 100;
+        let walker = WalkDir::new(project_root).into_iter();
+        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
+        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
+            let entry = entry.ok()?;
+
+            if let Some(pattern) = exclude_patterns {
+                let ignore_match =
+                    pattern.matched_path_or_any_parents(entry.path(), entry.file_type().is_dir());
+                if matches!(ignore_match, ignore::Match::Ignore(_)) {
+                    debug!(
+                        "The exclusion pattern got a match on {}: {:?}",
+                        entry.path().display(),
+                        ignore_match
+                    );
+                    return None;
+                }
+            }
+
+            let module = Self::qualified_module_name(&entry);
+            Some((entry.path().to_path_buf(), module))
+        }));
+
+        source_mod_pairs
+    }
 }
 
 impl ListAmFunctions for Impl {
     fn list_autometrics_functions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
         const PREALLOCATED_ELEMS: usize = 100;
         let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
-
-        let walker = WalkDir::new(project_root).into_iter();
-        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
-        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
-            let entry = entry.ok()?;
-            let module = Self::qualified_module_name(&entry);
-            Some((entry.path().to_path_buf(), module))
-        }));
+        let source_mod_pairs = Self::list_files_and_modules(project_root, None);
+        let query = AmQuery::try_new()?;
 
         list.par_extend(
             source_mod_pairs
                 .par_iter()
                 .filter_map(move |(path, module)| {
-                    let query = AmQuery::try_new().ok()?;
                     let source = read_to_string(path).ok()?;
                     let file_name = PathBuf::from(path)
                         .strip_prefix(project_root)
@@ -110,28 +142,14 @@ impl ListAmFunctions for Impl {
     fn list_all_function_definitions(&mut self, project_root: &Path) -> Result<Vec<FunctionInfo>> {
         const PREALLOCATED_ELEMS: usize = 100;
         let mut list = HashSet::with_capacity(PREALLOCATED_ELEMS);
-
-        let walker = WalkDir::new(project_root).into_iter();
-        let mut source_mod_pairs = Vec::with_capacity(PREALLOCATED_ELEMS);
-        source_mod_pairs.extend(walker.filter_entry(Self::is_valid).filter_map(|entry| {
-            let entry = entry.ok()?;
-            let module = Self::qualified_module_name(&entry);
-            Some((
-                entry
-                    .path()
-                    .to_str()
-                    .map(ToString::to_string)
-                    .unwrap_or_default(),
-                module,
-            ))
-        }));
+        let source_mod_pairs = Self::list_files_and_modules(project_root, None);
+        let query = AllFunctionsQuery::try_new()?;
 
         list.par_extend(
             source_mod_pairs
                 .par_iter()
                 .filter_map(move |(path, module)| {
                     let source = read_to_string(path).ok()?;
-                    let query = AllFunctionsQuery::try_new().ok()?;
                     let file_name = PathBuf::from(path)
                         .strip_prefix(project_root)
                         .expect("path comes from a project_root WalkDir")
@@ -141,13 +159,152 @@ impl ListAmFunctions for Impl {
                     let names = query
                         .list_function_names(&file_name, module, &source)
                         .ok()?;
-                    Some(names.into_iter().collect::<Vec<_>>())
+                    Some(
+                        names
+                            .into_iter()
+                            .map(|info| info.inner_info)
+                            .collect::<Vec<_>>(),
+                    )
                 }),
         );
 
         let mut result = Vec::with_capacity(PREALLOCATED_ELEMS);
         result.extend(list.into_iter().flatten());
+        trace!("Item list: {result:?}");
         Ok(result)
+    }
+
+    fn list_autometrics_functions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        let query = AmQuery::try_new()?;
+        query.list_function_names("<single file>", "", source_code, None)
+    }
+
+    fn list_all_function_definitions_in_single_file(
+        &mut self,
+        source_code: &str,
+    ) -> Result<Vec<FunctionInfo>> {
+        Ok(self
+            .ts_function_definitions_in_single_file(source_code)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+}
+
+impl InstrumentFile for Impl {
+    fn instrument_source_code(&mut self, source: &str) -> Result<String> {
+        let mut locations = self.list_all_functions_in_single_file(source)?;
+        locations.sort_by_key(|info| {
+            info.definition
+                .as_ref()
+                .map(|def| def.range.start.line)
+                .unwrap_or_default()
+        });
+
+        let mut ts_specific_locations = self.ts_function_definitions_in_single_file(source)?;
+        ts_specific_locations.sort_by_key(|info| {
+            info.inner_info
+                .definition
+                .as_ref()
+                .map(|def| def.range.start.line)
+                .unwrap_or_default()
+        });
+
+        let has_am_directive = source.lines().any(|line| {
+            line.contains("import { autometrics } from")
+                || line.contains("import { Autometrics } from")
+                || line.contains("import { autometrics, Autometrics } from")
+        });
+        let mut placeholder_offset_range = None;
+        let mut needs_decorator_import = false;
+        let mut needs_wrapper_import = false;
+
+        let mut new_code = crop::Rope::from(source);
+        // Keeping track of inserted lines to update the byte offset to insert code to,
+        // only works if the locations list is sorted from top to bottom
+        let mut inserted_lines = 0;
+
+        if !has_am_directive {
+            new_code.insert(
+                0,
+                "import { placeholder } from '@autometrics/autometrics';\n",
+            );
+            inserted_lines += 1;
+            placeholder_offset_range = Some("import { ".len().."import { placeholder".len());
+        }
+
+        for function_info in locations {
+            if function_info.definition.is_none() || function_info.instrumentation.is_some() {
+                continue;
+            }
+
+            let ts_loc = ts_specific_locations
+                .iter()
+                .find_map(|info| {
+                    if info.inner_info.id == function_info.id {
+                        Some(info.function_rvalue_range.clone())
+                    } else {
+                        None
+                    }
+                })
+                .flatten();
+
+            match ts_loc {
+                Some(rvalue_range) => {
+                    let start_byte_offset = new_code
+                        .byte_of_line(inserted_lines + rvalue_range.start.line)
+                        + rvalue_range.start.column;
+                    new_code.insert(start_byte_offset, "autometrics(");
+                    let end_byte_offset = new_code
+                        .byte_of_line(inserted_lines + rvalue_range.end.line)
+                        + rvalue_range.end.column;
+                    new_code.insert(end_byte_offset, ")");
+                    needs_wrapper_import = true;
+                }
+                None => {
+                    let def_line = function_info.definition.as_ref().unwrap().range.start.line;
+                    let byte_offset = new_code.byte_of_line(inserted_lines + def_line);
+                    new_code.insert(byte_offset, "@Autometrics()\n");
+                    inserted_lines += 1;
+                    needs_decorator_import = true;
+                }
+            }
+        }
+
+        if let Some(range) = placeholder_offset_range {
+            let imports = match (needs_wrapper_import, needs_decorator_import) {
+                (true, true) => "autometrics, Autometrics",
+                (true, false) => "autometrics",
+                (false, true) => "Autometrics",
+                (false, false) => "",
+            };
+            new_code.replace(range, imports);
+        }
+
+        Ok(new_code.to_string())
+    }
+
+    fn instrument_project(
+        &mut self,
+        project_root: &Path,
+        exclude_patterns: Option<&ignore::gitignore::Gitignore>,
+    ) -> Result<()> {
+        let sources_modules = Self::list_files_and_modules(project_root, exclude_patterns);
+
+        for (path, _module) in sources_modules {
+            if std::fs::metadata(&path)?.is_dir() {
+                continue;
+            }
+            debug!("Instrumenting {}", path.display());
+            let old_source = read_to_string(&path)?;
+            let new_source = self.instrument_source_code(&old_source)?;
+            std::fs::write(path, new_source)?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds the `am instrument` subcommand. It leverages tree-sitter to edit files in a project and add instrumentation annotations in a codebase.

In order to make this work, issues in Typescript queries were detected so the PR also fixes ts queries. Also, a slight refactoring (DRY) was applied on the codebase in general to reuse the project tree-walking code everywhere

# Checklist

- [x] Changelog updated
